### PR TITLE
Added ^ in react-scripts:1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react": "^16.4.0",
     "react-bootstrap": "^0.32.1",
     "react-dom": "^16.3.0",
-    "react-scripts": "1.1.1",
+    "react-scripts": "^1.1.1",
     "reactstrap": "^5.0.0",
     "tachyons": "^4.10.0"
   },


### PR DESCRIPTION
Just added caret '^' in package.json file before "react-scripts": "1.1.1" version specification. I have added this as I was not able to install node dependency modules. Could you please review it?   
