### PR TITLE
fix: sign up page -- show password element id mistype

### DIFF
--- a/src/components/SignUpPage/SignUpPage.jsx
+++ b/src/components/SignUpPage/SignUpPage.jsx
@@ -36,7 +36,7 @@ const SignUpPage = () =>{
 
   const showPassword = () =>{
     document.getElementById('password').type = document.getElementById('password').type === 'text'?'password':'text'
-    document.getElementById('ConfirmPassword').type = document.getElementById('confirmPassword').type === 'text'?'password':'text'
+    document.getElementById('confirmPassword').type = document.getElementById('confirmPassword').type === 'text'?'password':'text'
   }
 
 


### PR DESCRIPTION
- On signup page, "show password" checkbox is producing an error, because of a mistype of the "confirmPassword" element id.

The id of the element is [here](https://github.com/zero-to-mastery/book-tracker/blob/2f1d87767843f78f1a6ab546e0900ee20d5475c7/src/components/SignUpPage/SignUpPage.jsx#L74)