### PR TITLE
fix: sign up page not working as expected

### DIFF
--- a/backend/src/controllers/user.controller.js
+++ b/backend/src/controllers/user.controller.js
@@ -37,6 +37,7 @@ export default {
       res.header("x-auth-token", token).status(201).send({
         message: "User successfully registered",
         user: user._id,
+        token
       });
     } catch (err) {
       res.status(400).json(err);

--- a/src/components/SignUpPage/SignUpPage.jsx
+++ b/src/components/SignUpPage/SignUpPage.jsx
@@ -4,7 +4,7 @@ import SignUpService from "../../services/signUp.service";
 import { AlteredTextField } from "./AlteredTextField/AlteredTextField";
 import { formFields } from "./SignUpFormFields";
 
-const SignUpPage = () =>{
+const SignUpPage = ({ history }) =>{
 
   const [data, setData] = useState({
     name: '',
@@ -22,10 +22,15 @@ const SignUpPage = () =>{
       // setErrors({...errors, ["confirmPassword"]:"passwords dont match"})
       setErrors({['confirmPassword']: 'passwords dont match'})
     }else{
-      const response = await SignUpService.request(JSON.stringify({name, email, password}))
-      if(response.error){
-        setErrors({...response.body.details})
+      const {body, error} = await SignUpService.request(JSON.stringify({name, email, password}))
+
+      if(error){
+        setErrors({...body.details})
+        return
       }
+
+      localStorage.setItem("token", body.token)
+      history.push("/")
     }
   }
 
@@ -42,7 +47,7 @@ const SignUpPage = () =>{
 
   return(
     <React.Fragment>
-      <form onSubmit={handleSubmit} className='form-container'>
+      <form className='form-container'>
         <h2>Sign Up</h2>
         <input 
         type="text" 
@@ -81,7 +86,7 @@ const SignUpPage = () =>{
         <input type="checkbox" onClick={showPassword} style={{ width: "2%" }} />
         <span style={{ color: "white", fontSize: "0.8rem" }}>Show password</span>
       </div>
-      <button style={{ position: "relative", left: "43%" }}>Register</button>
+      <button style={{ position: "relative", left: "43%" }} onClick={handleSubmit}>Register</button>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Fixes to allow sign up page to work as expected (more similar to login flow):

- adds `onClick` to page's submit button
  -  ideally, button would be inside the form element, but current styles don't allow it 
- grabs auth token that is sent with successful user registration
  - sets auth token in local storage
  - redirects to '/'
  - this is how the current login flow operates


- outstanding issue:
  - the state of the user being logged in is determined once, at page load. Currently the login and sign up flows do not reflect user is logged in until page refresh. Log out button is not currently operational, either   

